### PR TITLE
Added prevEvent to "change" events and added "changing" event

### DIFF
--- a/src/leaflet-areaselect.js
+++ b/src/leaflet-areaselect.js
@@ -117,12 +117,13 @@ L.AreaSelect = L.Class.extend({
                 curX = event.originalEvent.pageX;
                 curY = event.originalEvent.pageY;
                 self._render();
+                self.fire("changing");
             }
             function onMouseUp(event) {
                 L.DomEvent.removeListener(self.map, "mouseup", onMouseUp);
                 L.DomEvent.removeListener(self.map, "mousemove", onMouseMove);
                 L.DomEvent.addListener(handle, "mousedown", onMouseDown);
-                self.fire("change");
+                self.fire("change", {prevEvent: event});
             }
             
             L.DomEvent.addListener(self.map, "mousemove", onMouseMove);
@@ -135,8 +136,8 @@ L.AreaSelect = L.Class.extend({
         this._render();
     },
     
-    _onMapChange: function() {
-        this.fire("change");
+    _onMapChange: function(event) {
+        this.fire("change", {prevEvent: event});
     },
     
     _render: function() {


### PR DESCRIPTION
A couple issues came up as a result of 0415463fa9331a547c3d798ebfce48564a494791.

When firing the `change` event, there's no way to know what triggered the change, whether it was [`setDimensions`](https://github.com/heyman/leaflet-areaselect/blob/0415463fa9331a547c3d798ebfce48564a494791/src/leaflet-areaselect.js#L56), [the initial setup](https://github.com/heyman/leaflet-areaselect/blob/0415463fa9331a547c3d798ebfce48564a494791/src/leaflet-areaselect.js#L84), [the map change](https://github.com/heyman/leaflet-areaselect/blob/0415463fa9331a547c3d798ebfce48564a494791/src/leaflet-areaselect.js#L139), or [mouseUp](https://github.com/heyman/leaflet-areaselect/blob/0415463fa9331a547c3d798ebfce48564a494791/src/leaflet-areaselect.js#L125)

Here's [a Plunk](http://plnkr.co/edit/twC2GLBUnUKYSCQGnWcc) demonstrating some of the oddities of this functionality. I modified the original demo and added some of my own functionality to it. With this Plunk, you can manually type in width/height, and update the box size. However, as you can see, the lack of knowing what fired the change event causes weird problems, such as not being able to increment the input by 1 (it only works in increments of even 2s).

Here's [a Plunk](http://plnkr.co/edit/yDAXi3t4kaLqOAvhPPdf?p=preview) with my PR's changes. You can see, it works as one would expect.

Secondly, would be super nice to get real time info on the bounding box when dragging, so I added a `changing` event on the `onMouseMove` method. Both Plunks reflect this.

Let me know if you need any more info or clarification. I tried my best to document this clearly :)
