### PR TITLE
Properly calculate the maxHeight variable when aspectRatio needs to be

### DIFF
--- a/src/leaflet-areaselect.js
+++ b/src/leaflet-areaselect.js
@@ -100,7 +100,7 @@ L.AreaSelect = L.Class.extend({
             
             function onMouseMove(event) {
                 if (self.options.keepAspectRatio) {
-                    var maxHeight = (self._height >= self._width ? size.y : size.y * (1/ratio) ) - 30;
+                    var maxHeight = (self._height >= self._width ? size.y : (size.x / ratio) ) - 30;
                     self._height += (curY - event.originalEvent.pageY) * 2 * yMod;
                     self._height = Math.max(30, self._height);
                     self._height = Math.min(maxHeight, self._height);


### PR DESCRIPTION
maintained

Previously, the maxHeight was calculated by using the size.y when the
width was >= the height. This was incorrect as it should be calculated
using the the max value (width in this case). Fixes a bug where the area
select could not be expanded beyond a small width value.