### PR TITLE
adds _touchHandler method and EventListeners for touch events

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -39,7 +39,7 @@
         L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
             attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         }).addTo(map);
-        debugger;
+
         var areaSelect = L.areaSelect({width:200, height:250});
         areaSelect.on("change", function() {
             var bounds = this.getBounds();

--- a/example/index.html
+++ b/example/index.html
@@ -6,30 +6,32 @@
     <link rel="stylesheet" href="../src/leaflet-areaselect.css" />
 </head>
 <body>
-    <div id="map"></div>    
+    <div id="map"></div>
     <div id="result">
         <div class="left">
             South west:<br>
             <input type="text" class="sw"><br>
-            
+
             North east:<br>
             <input type="text" class="ne">
-            
-            <button id="remove">Remove</button>            
+
+            <button id="remove">Remove</button>
         </div>
         <div class="right">
             Width:<br>
             <input type="text" class="width" /><br>
 
             Height:<br>
-            <input type="text" class="height" />       
-            <button id="setDimensions">Set Dimensions</button>     
+            <input type="text" class="height" />
+            <button id="setDimensions">Set Dimensions</button>
         </div>
     </div>
     <a href="https://github.com/heyman/leaflet-areaselect"><img style="position:absolute; top:0; right:0; border:0; z-index: 1000;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
-    
+
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
-    <script src="https://unpkg.com/leaflet@1.0.2/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.0.3/dist/leaflet.js"
+      integrity="sha512-A7vV8IFfih/D732iSSKi20u/ooOfj/AGehOKq0f4vLT1Zr2Y+RX7C+w8A1gaSasGtRUZpF/NZgzSAu4/Gc41Lg=="
+      crossorigin=""></script>
     <script src="../src/leaflet-areaselect.js"></script>
     <script>
         // initialize map
@@ -37,7 +39,7 @@
         L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
             attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
         }).addTo(map);
-        
+        debugger;
         var areaSelect = L.areaSelect({width:200, height:250});
         areaSelect.on("change", function() {
             var bounds = this.getBounds();
@@ -45,7 +47,7 @@
             $("#result .ne").val(bounds.getNorthEast().lat + ", " + bounds.getNorthEast().lng);
         });
         areaSelect.addTo(map);
-        
+
         $("#remove").click(function() {
             areaSelect.remove();
         });

--- a/src/leaflet-areaselect.js
+++ b/src/leaflet-areaselect.js
@@ -1,6 +1,6 @@
 L.AreaSelect = L.Class.extend({
     includes: L.Mixin.Events,
-    
+
     options: {
         width: 200,
         height: 300,
@@ -9,43 +9,49 @@ L.AreaSelect = L.Class.extend({
 
     initialize: function(options) {
         L.Util.setOptions(this, options);
-        
+
         this._width = this.options.width;
         this._height = this.options.height;
+
+        // make touch events simulate mouse events via _touchHandler
+        document.addEventListener("touchstart", this._touchHandler, true);
+        document.addEventListener("touchmove", this._touchHandler, true);
+        document.addEventListener("touchend", this._touchHandler, true);
+        document.addEventListener("touchcancel", this._touchHandler, true);
     },
-    
+
     addTo: function(map) {
         this.map = map;
         this._createElements();
         this._render();
         return this;
     },
-    
+
     getBounds: function() {
         var size = this.map.getSize();
         var topRight = new L.Point();
         var bottomLeft = new L.Point();
-        
+
         bottomLeft.x = Math.round((size.x - this._width) / 2);
         topRight.y = Math.round((size.y - this._height) / 2);
         topRight.x = size.x - bottomLeft.x;
         bottomLeft.y = size.y - topRight.y;
-        
+
         var sw = this.map.containerPointToLatLng(bottomLeft);
         var ne = this.map.containerPointToLatLng(topRight);
-        
+
         return new L.LatLngBounds(sw, ne);
     },
-    
+
     remove: function() {
         this.map.off("moveend", this._onMapChange);
         this.map.off("zoomend", this._onMapChange);
         this.map.off("resize", this._onMapResize);
-        
+
         this._container.parentNode.removeChild(this._container);
     },
 
-    
+
     setDimensions: function(dimensions) {
         if (!dimensions)
             return;
@@ -56,38 +62,38 @@ L.AreaSelect = L.Class.extend({
         this.fire("change");
     },
 
-    
+
     _createElements: function() {
         if (!!this._container)
             return;
-        
+
         this._container = L.DomUtil.create("div", "leaflet-areaselect-container", this.map._controlContainer)
         this._topShade = L.DomUtil.create("div", "leaflet-areaselect-shade leaflet-control", this._container);
         this._bottomShade = L.DomUtil.create("div", "leaflet-areaselect-shade leaflet-control", this._container);
         this._leftShade = L.DomUtil.create("div", "leaflet-areaselect-shade leaflet-control", this._container);
         this._rightShade = L.DomUtil.create("div", "leaflet-areaselect-shade leaflet-control", this._container);
-        
+
         this._nwHandle = L.DomUtil.create("div", "leaflet-areaselect-handle leaflet-control", this._container);
         this._swHandle = L.DomUtil.create("div", "leaflet-areaselect-handle leaflet-control", this._container);
         this._neHandle = L.DomUtil.create("div", "leaflet-areaselect-handle leaflet-control", this._container);
         this._seHandle = L.DomUtil.create("div", "leaflet-areaselect-handle leaflet-control", this._container);
-        
+
         this._setUpHandlerEvents(this._nwHandle);
         this._setUpHandlerEvents(this._neHandle, -1, 1);
         this._setUpHandlerEvents(this._swHandle, 1, -1);
         this._setUpHandlerEvents(this._seHandle, -1, -1);
-        
+
         this.map.on("moveend", this._onMapChange, this);
         this.map.on("zoomend", this._onMapChange, this);
         this.map.on("resize", this._onMapResize, this);
-        
+
         this.fire("change");
     },
-    
+
     _setUpHandlerEvents: function(handle, xMod, yMod) {
         xMod = xMod || 1;
         yMod = yMod || 1;
-        
+
         var self = this;
         function onMouseDown(event) {
             event.stopPropagation();
@@ -97,7 +103,7 @@ L.AreaSelect = L.Class.extend({
             var curY = event.pageY;
             var ratio = self._width / self._height;
             var size = self.map.getSize();
-            
+
             function onMouseMove(event) {
                 if (self.options.keepAspectRatio) {
                     var maxHeight = (self._height >= self._width ? size.y : size.y * (1/ratio) ) - 30;
@@ -112,9 +118,9 @@ L.AreaSelect = L.Class.extend({
                     self._height = Math.max(30, self._height);
                     self._width = Math.min(size.x-30, self._width);
                     self._height = Math.min(size.y-30, self._height);
-                    
+
                 }
-                
+
                 curX = event.originalEvent.pageX;
                 curY = event.originalEvent.pageY;
                 self._render();
@@ -126,28 +132,28 @@ L.AreaSelect = L.Class.extend({
                 L.DomEvent.addListener(handle, "mousedown", onMouseDown);
                 self.fire("change");
             }
-            
+
             L.DomEvent.addListener(self.map, "mousemove", onMouseMove);
             L.DomEvent.addListener(self.map, "mouseup", onMouseUp);
         }
         L.DomEvent.addListener(handle, "mousedown", onMouseDown);
     },
-    
+
     _onMapResize: function() {
         this._render();
     },
-    
+
     _onMapChange: function() {
         this.fire("change");
     },
-    
+
     _render: function() {
         var size = this.map.getSize();
         var handleOffset = Math.round(this._nwHandle.offsetWidth/2);
-        
+
         var topBottomHeight = Math.round((size.y-this._height)/2);
         var leftRightWidth = Math.round((size.x-this._width)/2);
-        
+
         function setDimensions(element, dimension) {
             element.style.width = dimension.width + "px";
             element.style.height = dimension.height + "px";
@@ -156,26 +162,52 @@ L.AreaSelect = L.Class.extend({
             element.style.bottom = dimension.bottom + "px";
             element.style.right = dimension.right + "px";
         }
-        
+
         setDimensions(this._topShade, {width:size.x, height:topBottomHeight, top:0, left:0});
         setDimensions(this._bottomShade, {width:size.x, height:topBottomHeight, bottom:0, left:0});
         setDimensions(this._leftShade, {
-            width: leftRightWidth, 
-            height: size.y-(topBottomHeight*2), 
-            top: topBottomHeight, 
+            width: leftRightWidth,
+            height: size.y-(topBottomHeight*2),
+            top: topBottomHeight,
             left: 0
         });
         setDimensions(this._rightShade, {
-            width: leftRightWidth, 
-            height: size.y-(topBottomHeight*2), 
-            top: topBottomHeight, 
+            width: leftRightWidth,
+            height: size.y-(topBottomHeight*2),
+            top: topBottomHeight,
             right: 0
         });
-        
+
         setDimensions(this._nwHandle, {left:leftRightWidth-handleOffset, top:topBottomHeight-7});
         setDimensions(this._neHandle, {right:leftRightWidth-handleOffset, top:topBottomHeight-7});
         setDimensions(this._swHandle, {left:leftRightWidth-handleOffset, bottom:topBottomHeight-7});
         setDimensions(this._seHandle, {right:leftRightWidth-handleOffset, bottom:topBottomHeight-7});
+    },
+
+    _touchHandler : function(event) {
+        // Add touch support by converting touch events to mouse events
+        // Source: http://stackoverflow.com/a/6362527/725573
+
+        var touches = event.changedTouches,
+            first = touches[0],
+            type = "";
+
+        switch(event.type) {
+            case "touchstart": type = "mousedown"; break;
+            case "touchmove":  type = "mousemove"; break;
+            case "touchend":   type = "mouseup";   break;
+            default: return;
+        }
+
+        //Convert the touch event into it's corresponding mouse event
+        var simulatedEvent = document.createEvent("MouseEvent");
+        simulatedEvent.initMouseEvent(type, true, true, window, 1,
+                                  first.screenX, first.screenY,
+                                  first.clientX, first.clientY, false,
+                                  false, false, false, 0/*left*/, null);
+
+        first.target.dispatchEvent(simulatedEvent);
+        event.preventDefault();
     }
 });
 

--- a/src/leaflet-areaselect.js
+++ b/src/leaflet-areaselect.js
@@ -12,12 +12,6 @@ L.AreaSelect = L.Class.extend({
 
         this._width = this.options.width;
         this._height = this.options.height;
-
-        // make touch events simulate mouse events via _touchHandler
-        document.addEventListener("touchstart", this._touchHandler, true);
-        document.addEventListener("touchmove", this._touchHandler, true);
-        document.addEventListener("touchend", this._touchHandler, true);
-        document.addEventListener("touchcancel", this._touchHandler, true);
     },
 
     addTo: function(map) {
@@ -137,6 +131,12 @@ L.AreaSelect = L.Class.extend({
             L.DomEvent.addListener(self.map, "mouseup", onMouseUp);
         }
         L.DomEvent.addListener(handle, "mousedown", onMouseDown);
+
+         // make touch events simulate mouse events via _touchHandler
+        handle.addEventListener("touchstart", this._touchHandler, true);
+        handle.addEventListener("touchmove", this._touchHandler, true);
+        handle.addEventListener("touchend", this._touchHandler, true);
+        handle.addEventListener("touchcancel", this._touchHandler, true);
     },
 
     _onMapResize: function() {


### PR DESCRIPTION
...also updates Leaflet.js dependency to version 1.0.3.

I basically followed the suggestions from issue https://github.com/heyman/leaflet-areaselect/issues/1.

This works for me.  I think this fix has implications outside of  areaselect, since it attaches the touch event handlers to `document`.

 