### PR TITLE
turn HTTPS on everywhere

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -28,14 +28,14 @@
     </div>
     <a href="https://github.com/heyman/leaflet-areaselect"><img style="position:absolute; top:0; right:0; border:0; z-index: 1000;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png" alt="Fork me on GitHub"></a>
     
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
     <script src="https://unpkg.com/leaflet@1.0.2/dist/leaflet.js"></script>
     <script src="../src/leaflet-areaselect.js"></script>
     <script>
         // initialize map
         var map = L.map('map').setView([38, 0], 2);
-        L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap</a> contributors'
         }).addTo(map);
         
         var areaSelect = L.areaSelect({width:200, height:250});


### PR DESCRIPTION
set https on urls to fix "Blocked loading mixed active content" error in modern browsers