### PR TITLE
Ended L.areaSelect definition with a semicolon

### DIFF
--- a/src/leaflet-areaselect.js
+++ b/src/leaflet-areaselect.js
@@ -181,4 +181,4 @@ L.AreaSelect = L.Class.extend({
 
 L.areaSelect = function(options) {
     return new L.AreaSelect(options);
-}
+};


### PR DESCRIPTION
I noticed when I was using the library in conjunction with `grunt-contrib-uglify`, there was some unfortunate concatenation happening. Because `leaflet-areaselect.js` doesn't end in a `;`, the contents of another dependency were concatenated directly after the assignment to `L.areaSelect`.
That created an unintentional IIFE- `L.areaSelect` became a full instance of `L.AreaSelect` instead of the generator function, so later on you get an `L.areaSelect is not a function` error when trying to use the plugin. Basically my minified file ended up looking like : 

`L.areaSelect=function(a){return new L.AreaSelect(a)}(function(){ ... }());`

This pull request just adds the errant semicolon to prevent this condition.