### PR TITLE
getDimensions method added

### DIFF
--- a/src/leaflet-areaselect.js
+++ b/src/leaflet-areaselect.js
@@ -57,6 +57,14 @@ L.AreaSelect = L.Class.extend({
     },
 
     
+    getDimensions: function () {
+        return {
+            height: this._height,
+            width: this._width
+        };
+    },
+	
+	
     _createElements: function() {
         if (!!this._container)
             return;


### PR DESCRIPTION
I'm using AreaSelect to define an area of the map to print. getDimensions() allows me to retrieve the current dimension so I can invert them before calling setDimensions(dimensions) when the user toggles between landscape and portrait orientations.

Thanks for sharing your code, it's much appreciated! :) 