### PR TITLE
Added new function getBBoxCoordinates and updated readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,12 @@ Example Code
 .. code-block:: javascript
 
     var areaSelect = L.areaSelect({width:200, height:300, keepAspectRatio:true});
+    
+**If you need the coordinates for all four corners of the bounding box:**
+
+.. code-block:: javascript
+
+    var bboxCoordinates = areaSelect.getBBoxCoordinates();
 
 
 See it in action

--- a/src/leaflet-areaselect.js
+++ b/src/leaflet-areaselect.js
@@ -37,6 +37,35 @@ L.AreaSelect = L.Class.extend({
         return new L.LatLngBounds(sw, ne);
     },
     
+    getBBoxCoordinates: function() {
+        var size = this.map.getSize();
+      
+        var topRight = new L.Point();
+        var bottomLeft = new L.Point();
+        var topLeft = new L.Point();
+        var bottomRight = new L.Point();
+
+        bottomLeft.x = Math.round((size.x - this._width) / 2);
+        topRight.y = Math.round((size.y - this._height) / 2);
+        topRight.x = size.x - bottomLeft.x;
+        bottomLeft.y = size.y - topRight.y;
+
+        topLeft.x = bottomLeft.x;
+        topLeft.y = topRight.y;
+        bottomRight.x = topRight.x;
+        bottomRight.y = bottomLeft.y;
+
+        var coordinates = 
+            [
+                {"sw": this.map.containerPointToLatLng(bottomLeft)},
+                {"nw": this.map.containerPointToLatLng(topLeft)},
+                {"ne": this.map.containerPointToLatLng(topRight)},
+                {"se": this.map.containerPointToLatLng(bottomRight)}
+            ]
+		
+        return coordinates
+    },
+    
     remove: function() {
         this.map.off("moveend", this._onMapChange);
         this.map.off("zoomend", this._onMapChange);

--- a/src/leaflet-areaselect.js
+++ b/src/leaflet-areaselect.js
@@ -1,5 +1,5 @@
 L.AreaSelect = L.Class.extend({
-    includes: L.Mixin.Events,
+    includes: L.Evented.prototype,
     
     options: {
         width: 200,


### PR DESCRIPTION
Hi,

I just came into a situation where I needed all four corners of the bounding box, i.e. to work with geospatial queries in MongoDB. Thus, I added a new function, which returns an object that contains the coordinate pairs of all four corners. I also updated the readme to show, how to call it.

I hope this can be useful to the crowd.

Thanks!

Cheers,
Tom