### PR TITLE
More options and touch events

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ Example Code
 .. code-block:: javascript
 
     // Add it to the map
-    var areaSelect = L.areaSelect({width:200, height:300});
+    var areaSelect = L.areaSelect({width:200, height:300, minWidth:40, minHeight:40, minHorizontalSpacing:40, minVerticalSpacing:100});
     areaSelect.addTo(map);
     
     // Read the bouding box

--- a/src/leaflet-areaselect.js
+++ b/src/leaflet-areaselect.js
@@ -1,9 +1,13 @@
 L.AreaSelect = L.Class.extend({
     includes: L.Evented.prototype,
-    
+
     options: {
         width: 200,
         height: 300,
+        minWidth: 30,
+        minHeight: 30,
+        minHorizontalSpacing: 30,
+        minVerticalSpacing: 30,
         keepAspectRatio: false,
     },
 
@@ -129,19 +133,18 @@ L.AreaSelect = L.Class.extend({
             
             function onMouseMove(event) {
                 if (self.options.keepAspectRatio) {
-                    var maxHeight = (self._height >= self._width ? size.y : size.y * (1/ratio) ) - 30;
+                    var maxHeight = (self._height >= self._width ? size.y : size.y * (1/ratio) ) - Math.max(self.options.minVerticalSpacing, self.options.minHorizontalSpacing);
                     self._height += (curY - event.originalEvent.pageY) * 2 * yMod;
-                    self._height = Math.max(30, self._height);
+                    self._height = Math.max(self.options.minHeight, self.options.minWidth, self._height);
                     self._height = Math.min(maxHeight, self._height);
                     self._width = self._height * ratio;
                 } else {
                     self._width += (curX - event.originalEvent.pageX) * 2 * xMod;
                     self._height += (curY - event.originalEvent.pageY) * 2 * yMod;
-                    self._width = Math.max(30, self._width);
-                    self._height = Math.max(30, self._height);
-                    self._width = Math.min(size.x-30, self._width);
-                    self._height = Math.min(size.y-30, self._height);
-                    
+                    self._width = Math.max(self.options.minWidth, self._width);
+                    self._height = Math.max(self.options.minHeight, self._height);
+                    self._width = Math.min(size.x-self.options.minHorizontalSpacing, self._width);
+                    self._height = Math.min(size.y-self.options.minVerticalSpacing, self._height);
                 }
                 
                 curX = event.originalEvent.pageX;

--- a/src/leaflet-areaselect.js
+++ b/src/leaflet-areaselect.js
@@ -125,44 +125,44 @@ L.AreaSelect = L.Class.extend({
         function onMouseDown(event) {
             event.stopPropagation();
             self.map.dragging.disable();
-            L.DomEvent.removeListener(this, "mousedown", onMouseDown);
+            L.DomEvent.removeListener(this, "touchstart", onMouseDown);
             var curX = event.pageX;
             var curY = event.pageY;
             var ratio = self._width / self._height;
             var size = self.map.getSize();
+            var mapContainer = self.map.getContainer();
             
             function onMouseMove(event) {
                 if (self.options.keepAspectRatio) {
                     var maxHeight = (self._height >= self._width ? size.y : size.y * (1/ratio) ) - Math.max(self.options.minVerticalSpacing, self.options.minHorizontalSpacing);
-                    self._height += (curY - event.originalEvent.pageY) * 2 * yMod;
+                    self._height += (curY - event.pageY) * 2 * yMod;
                     self._height = Math.max(self.options.minHeight, self.options.minWidth, self._height);
                     self._height = Math.min(maxHeight, self._height);
                     self._width = self._height * ratio;
                 } else {
-                    self._width += (curX - event.originalEvent.pageX) * 2 * xMod;
-                    self._height += (curY - event.originalEvent.pageY) * 2 * yMod;
+                    self._width += (curX - event.pageX) * 2 * xMod;
+                    self._height += (curY - event.pageY) * 2 * yMod;
                     self._width = Math.max(self.options.minWidth, self._width);
                     self._height = Math.max(self.options.minHeight, self._height);
                     self._width = Math.min(size.x-self.options.minHorizontalSpacing, self._width);
                     self._height = Math.min(size.y-self.options.minVerticalSpacing, self._height);
                 }
                 
-                curX = event.originalEvent.pageX;
-                curY = event.originalEvent.pageY;
+                curX = event.pageX;
+                curY = event.pageY;
                 self._render();
             }
             function onMouseUp(event) {
                 self.map.dragging.enable();
-                L.DomEvent.removeListener(self.map, "mouseup", onMouseUp);
-                L.DomEvent.removeListener(self.map, "mousemove", onMouseMove);
-                L.DomEvent.addListener(handle, "mousedown", onMouseDown);
+                L.DomEvent.removeListener(mapContainer, "touchend", onMouseUp);
+                L.DomEvent.removeListener(mapContainer, "touchmove", onMouseMove);
+                L.DomEvent.addListener(handle, "touchstart", onMouseDown);
                 self.fire("change");
             }
-            
-            L.DomEvent.addListener(self.map, "mousemove", onMouseMove);
-            L.DomEvent.addListener(self.map, "mouseup", onMouseUp);
+            L.DomEvent.addListener(mapContainer, "touchmove", onMouseMove);
+            L.DomEvent.addListener(mapContainer, "touchend", onMouseUp);
         }
-        L.DomEvent.addListener(handle, "mousedown", onMouseDown);
+        L.DomEvent.addListener(handle, "touchstart", onMouseDown);
     },
     
     _onMapResize: function() {


### PR DESCRIPTION
### Description

Added more options regarding the size of the area to select, by replacing hard coded numbers with variables. This can be useful in situations where there are elements, such as controls, on top of the map, preventing the area from overlapping. Also replaced the mouse events with touch events to support mobile devices. 

#### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

### How Has This Been Tested?

Manual testing done on Firefox 84, Chrome 87 and mobile Chrome on Samsung Galaxy S10 Plus on Browserstack.com. 
Tested against Leaflet version 1.7.1.
No unit tests previously and none were added.

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules